### PR TITLE
Changed eval() to indexing methods

### DIFF
--- a/leaflet.js
+++ b/leaflet.js
@@ -81,9 +81,9 @@ if (document.querySelector('input[name="selectBackground"]')) {
         elem.addEventListener("change", function (event) {
             var item = event.target.value;
             for (let key in MapLayers.Basemaps) {
-                eval("MapLayers.Basemaps." + key).remove();
+                MapLayers.Basemaps[key].remove();
             };
-            eval("MapLayers.Basemaps." + item).addTo(lfmap);
+            MapLayers.Basemaps[item].addTo(lfmap);
         });
     });
 }

--- a/maplayers.js
+++ b/maplayers.js
@@ -159,10 +159,10 @@ sources.forEach(source => {
                     }
                     if (!feature.properties.skip) { // för att dölja vissa stigar
                         if (typeof (feature.properties.group) === 'string') {
-                            eval("groups." + feature.properties.group).addLayer(layer);
+                            groups[feature.properties.group].addLayer(layer);
                         } else {
                             feature.properties.group.forEach(element => {
-                                eval("groups." + element).addLayer(layer);
+                                groups[element].addLayer(layer);
                             })
                         }
                     }
@@ -170,7 +170,7 @@ sources.forEach(source => {
                 pointToLayer: function (feature, latlng) {
                     if (feature.properties.icon) {
                         thisMarker = L.marker(latlng, {
-                            icon: eval("icons." + feature.properties.icon),
+                            icon: icons[feature.properties.icon],
                         });
                     } else {
                         thisMarker = L.marker(latlng, {


### PR DESCRIPTION
`eval()` använder string-manipulering och är lite riskiga, därför ändrade jag maplayers för att använda indexing istället i både `leaflet.js` och `maplayers.js`

Exempelvis:
```js
/* maplayers.js: sources.forEach: .then: L.geoJSON: onEachFeature */

eval("groups." + feature.properties.group);
```
blev
```js
/* maplayers.js: sources.forEach: .then: L.geoJSON: onEachFeature */

groups[feature.properties.group];
```
```js
/* maplayer.js: sources.forEach: .then: L.geoJSON: onEachFeature */

eval("icons." + feature.properties.icon);
```
blev:
```js
/* maplayer.js: sources.forEach: .then: L.geoJSON: onEachFeature */

icons[feature.properties.icon];
```